### PR TITLE
Remove Unnecessary Require

### DIFF
--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -1,5 +1,4 @@
 require 'net/ssh/loggable'
-require 'net/sftp/operations/file'
 
 module Net; module SFTP; module Operations
 


### PR DESCRIPTION
This one-line patch changes `net/sftp/operations/file` to not try requiring itself, which causes a very chatty warning in Ruby 1.9.2. Also, it's pointless. :)
