### PR TITLE
Allow for upload to use the filename of the local file by default and test

### DIFF
--- a/lib/net/sftp/session.rb
+++ b/lib/net/sftp/session.rb
@@ -94,12 +94,12 @@ module Net; module SFTP
       #
       #   uploader = sftp.upload("/local/path", "/remote/path")
       #   uploader.wait
-      def upload(local, remote, options={}, &block)
+      def upload(local, remote = File.basename(local), options={}, &block)
         Operations::Upload.new(self, local, remote, options, &block)
       end
 
       # Identical to #upload, but blocks until the upload is complete.
-      def upload!(local, remote, options={}, &block)
+      def upload!(local, remote = File.basename(local), options={}, &block)
         upload(local, remote, options, &block).wait
       end
 

--- a/test/test_upload.rb
+++ b/test/test_upload.rb
@@ -10,6 +10,20 @@ class UploadTest < Net::SFTP::TestCase
     assert_scripted_command { sftp.upload("/path/to/local", "/path/to/remote") }
   end
 
+  def test_upload_file_without_remote_uses_filename_of_local_file
+    expect_file_transfer("/path/to/local", "local", "here are the contents")
+
+    assert_scripted_command do
+      sftp.upload("/path/to/local") { |*args| record_progress(args) }
+    end
+
+    assert_progress_reported_open(:remote => "local")
+    assert_progress_reported_put(0, "here are the contents", :remote => "local")
+    assert_progress_reported_close(:remote => "local")
+    assert_progress_reported_finish
+    assert_no_more_reported_events
+  end
+
   def test_upload_file_with_progress_should_report_progress
     expect_file_transfer("/path/to/local", "/path/to/remote", "here are the contents")
 


### PR DESCRIPTION
Allow for upload to use the filename of the local file as default and test. This is similar to the put behavior in Net::FTP.
