### PR TITLE
Properly handle receiving less data than requested

### DIFF
--- a/lib/net/sftp/operations/download.rb
+++ b/lib/net/sftp/operations/download.rb
@@ -318,7 +318,6 @@ module Net; module SFTP; module Operations
         request = sftp.read(entry.handle, entry.offset, read_size, &method(:on_read))
         request[:entry] = entry
         request[:offset] = entry.offset
-        entry.offset += read_size
       end
 
       # Called when a read from a file finishes. If the read was successful
@@ -335,6 +334,7 @@ module Net; module SFTP; module Operations
         elsif !response.ok?
           raise "read #{entry.remote}: #{response}"
         else
+          entry.offset += response[:data].bytesize
           update_progress(:get, entry, response.request[:offset], response[:data])
           entry.sink.write(response[:data])
           download_next_chunk(entry)


### PR DESCRIPTION
Some sftp servers put an upper bound on the amount of data sent as response to a single request (for example `sftp-server` shipped with OS X 10.6 only sends out a maximum of 65KB per FXP_READ).
