### PR TITLE
Support skipping file downloads

### DIFF
--- a/lib/net/sftp/operations/download.rb
+++ b/lib/net/sftp/operations/download.rb
@@ -287,9 +287,16 @@ module Net; module SFTP; module Operations
 
       # Called when a file is to be opened for reading from the remote server.
       def open_file(entry)
-        update_progress(:open, entry)
-        request = sftp.open(entry.remote, &method(:on_open))
-        request[:entry] = entry
+        continue = catch(:skip) do
+          update_progress(:open, entry)
+          request = sftp.open(entry.remote, &method(:on_open))
+          request[:entry] = entry
+          true
+        end
+        unless continue
+          @active -= 1
+          process_next_entry
+        end
       end
 
       # Called when a directory handle is closed.


### PR DESCRIPTION
I've started to write a script that is meant to regularly download new photos from my phone running sshd. sftp's recursive download does most of the work, but it has no way of skipping files that already exist locally.

My pull request comprises a tiny, proof-of-concept patch that supports writing code like this

``` ruby
  sftp.download(CAMERA_PATH, LOCAL_PATH, recursive: true) do |event, downloader, *args|
    case event
    when :open then
      # args[0] : file metadata
      if File.file?(args[0].local)
        puts "SKIPPING download: #{args[0].remote} already exists #{args[0].local}"
        throw :skip ### this is new
      else
        puts "starting download: #{args[0].remote} -> #{args[0].local} (#{args[0].size} bytes}"
      end
      ...
  end
```

Please consider my patch or a similar mechanism for a future version.

Michael
