### PR TITLE
Minitest 5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ begin
 
     s.add_dependency 'net-ssh', ">=2.6.5"
 
-    s.add_development_dependency 'test-unit'
+    s.add_development_dependency 'minitest', '>=5'
     s.add_development_dependency 'mocha'
 
     s.license = "MIT"

--- a/net-sftp.gemspec
+++ b/net-sftp.gemspec
@@ -90,16 +90,16 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<net-ssh>, [">= 2.6.5"])
-      s.add_development_dependency(%q<test-unit>, [">= 0"])
+      s.add_development_dependency(%q<minitest>, [">= 5"])
       s.add_development_dependency(%q<mocha>, [">= 0"])
     else
       s.add_dependency(%q<net-ssh>, [">= 2.6.5"])
-      s.add_dependency(%q<test-unit>, [">= 0"])
+      s.add_dependency(%q<minitest>, [">= 5"])
       s.add_dependency(%q<mocha>, [">= 0"])
     end
   else
     s.add_dependency(%q<net-ssh>, [">= 2.6.5"])
-    s.add_dependency(%q<test-unit>, [">= 0"])
+    s.add_dependency(%q<minitest>, [">= 5"])
     s.add_dependency(%q<mocha>, [">= 0"])
   end
 end

--- a/test/common.rb
+++ b/test/common.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'mocha/setup'
 require 'stringio'
 
@@ -20,7 +20,7 @@ require 'net/sftp'
 require 'net/sftp/constants'
 require 'net/ssh/test'
 
-class Net::SFTP::TestCase < Test::Unit::TestCase
+class Net::SFTP::TestCase < Minitest::Test
   include Net::SFTP::Constants::PacketTypes
   include Net::SSH::Test
 

--- a/test/protocol/01/test_base.rb
+++ b/test/protocol/01/test_base.rb
@@ -44,7 +44,7 @@ class Protocol::V01::TestBase < Net::SFTP::TestCase
       :string, "name2", :string, "long2", :long, 0x4, :long, 0550)
     names = @base.parse_name_packet(packet)[:names]
 
-    assert_not_nil names
+    refute_nil names
     assert_equal 2, names.length
     assert_instance_of Net::SFTP::Protocol::V01::Name, names.first
 

--- a/test/protocol/04/test_base.rb
+++ b/test/protocol/04/test_base.rb
@@ -17,7 +17,7 @@ class Protocol::V04::TestBase < Protocol::V03::TestBase
       :string, "name2", :long, 0x4, :byte, 1, :long, 0550)
     names = @base.parse_name_packet(packet)[:names]
 
-    assert_not_nil names
+    refute_nil names
     assert_equal 2, names.length
     assert_instance_of Net::SFTP::Protocol::V04::Name, names.first
 


### PR DESCRIPTION
Although it appears, that net-sftp depend on test-unit, it fails with recent test-unit with strange errors such as:

```
===============================================================================
Error: test_block_should_raise_not_implemented_error(Protocol::V01::TestBase)
  NoMethodError: undefined method `[]' for Net::SFTP::Protocol::V01::Attributes:Class
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/attribute.rb:125:in `[]'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/testcase.rb:683:in `run_test'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/testcase.rb:431:in `run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/testsuite.rb:121:in `run_test'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/testsuite.rb:53:in `run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/testsuite.rb:121:in `run_test'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/testsuite.rb:53:in `run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/ui/testrunnermediator.rb:65:in `run_suite'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/ui/testrunnermediator.rb:44:in `block in run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/ui/testrunnermediator.rb:100:in `with_listener'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/ui/testrunnermediator.rb:40:in `run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/ui/testrunner.rb:40:in `start_mediator'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/ui/testrunner.rb:25:in `start'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/ui/testrunnerutilities.rb:24:in `run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/autorunner.rb:409:in `block in run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/autorunner.rb:465:in `change_work_directory'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/autorunner.rb:408:in `run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit/autorunner.rb:59:in `run'
/usr/share/gems/gems/test-unit-2.5.5/lib/test/unit.rb:502:in `block (2 levels) in <top (required)>'
===============================================================================
```

It is actually designed around MiniTest 4.x test-unit wrapper shipped in Ruby. Since it seems that in future versions of Ruby, this wrapper will be removed, I'd like to suggest to migrate the test suite to plain MiniTest 5.x.
