### PR TITLE
Adding optional version parameter to SFTP session

### DIFF
--- a/lib/net/sftp/session.rb
+++ b/lib/net/sftp/session.rb
@@ -75,8 +75,9 @@ module Net; module SFTP
     #
     #   sftp = Net::SFTP::Session.new(ssh)
     #   sftp.loop { sftp.opening? }
-    def initialize(session, &block)
+    def initialize(session, version = nil, &block)
       @session    = session
+      @version    = version
       @input      = Net::SSH::Buffer.new
       self.logger = session.logger
       @state      = :closed
@@ -876,7 +877,7 @@ module Net; module SFTP
         channel.on_close(&method(:when_channel_closed))
         channel.on_process(&method(:when_channel_polled))
 
-        send_packet(FXP_INIT, :long, HIGHEST_PROTOCOL_VERSION_SUPPORTED)
+        send_packet(FXP_INIT, :long, @version || HIGHEST_PROTOCOL_VERSION_SUPPORTED)
       end
 
       # Called when the SSH server closes the underlying channel.


### PR DESCRIPTION
This change is to add option version to SFTP session to override HIGHEST_PROTOCOL_VERSION_SUPPORTED during negotiation. This parameter is useful when SFTP server has bug which terminates the connection before version negotiation if correct version is not passed.