### PR TITLE
Glob

### DIFF
--- a/lib/net/sftp/operations/dir.rb
+++ b/lib/net/sftp/operations/dir.rb
@@ -60,7 +60,7 @@ module Net; module SFTP; module Operations
       path = path.chop if path.end_with?('/') && path != '/'
 
       results = [] unless block_given?
-      queue = entries(path).reject { |e| e.name == "." || e.name == ".." }
+      queue = entries(path).reject { |e| %w(. ..).include?(e.name) }
       while queue.any?
         entry = queue.shift
 

--- a/lib/net/sftp/operations/dir.rb
+++ b/lib/net/sftp/operations/dir.rb
@@ -57,7 +57,7 @@ module Net; module SFTP; module Operations
     # it should be able to handle modest numbers of files in each directory.
     def glob(path, pattern, flags=0)
       flags |= ::File::FNM_PATHNAME
-      path = path.chop if path[-1,1] == "/"
+      path = path.chop if path.end_with?('/') && path != '/'
 
       results = [] unless block_given?
       queue = entries(path).reject { |e| e.name == "." || e.name == ".." }


### PR DESCRIPTION
I see some pretty basic problems with `Dir#glob`. This pull requests fixes just one of them: globs on the root directory `/` fail since the logic to remove a trailing slash on the initial path made the root path the empty string `""`. Then `#entries()` failed. (This still doesn't fix multiple trailing slashes).

The other problems that I see are:
 * `glob` always recurses (so globbing from `/` is never really practical, except on very small machines)
 * failure to open any directory anywhere under the initial path throws an exception and the glob fails
 * [POLS](https://en.wikipedia.org/wiki/Principle_of_least_astonishment): the comment says this works like `::Dir.glob` yet both the signature and the semantics differ.

Unfortunately to fix these problems (first, last) requires a backwards-incompatible change and a major version bump (respecting semver). (At least a change in signature is a clear signal to consumers). Would this project accept a PR for the above items at this stage in its life?