### PR TITLE
Protocole::V06::Extended

### DIFF
--- a/lib/net/sftp/protocol.rb
+++ b/lib/net/sftp/protocol.rb
@@ -4,6 +4,7 @@ require 'net/sftp/protocol/03/base'
 require 'net/sftp/protocol/04/base'
 require 'net/sftp/protocol/05/base'
 require 'net/sftp/protocol/06/base'
+require 'net/sftp/protocol/06/extended'
 
 module Net; module SFTP
 
@@ -22,7 +23,7 @@ module Net; module SFTP
       when 3 then V03::Base.new(session)
       when 4 then V04::Base.new(session)
       when 5 then V05::Base.new(session)
-      when 6 then V06::Base.new(session)
+      when 6 then V06::Extended.new(session)
       else raise NotImplementedError, "unsupported SFTP version #{version.inspect}"
       end
     end

--- a/lib/net/sftp/protocol/06/extended.rb
+++ b/lib/net/sftp/protocol/06/extended.rb
@@ -1,0 +1,107 @@
+require 'net/sftp/protocol/06/base'
+
+module Net; module SFTP; module Protocol; module V06
+
+  # Wraps the low-level SFTP calls for version 6 of the SFTP protocol.
+  #
+  # None of these protocol methods block--all of them return immediately,
+  # requiring the SSH event loop to be run while the server response is
+  # pending.
+  #
+  # You will almost certainly never need to use this driver directly. Please
+  # see Net::SFTP::Session for the recommended interface.
+  class Extended < V06::Base
+
+    # Parses the given "md5-hash" FXP_EXTENDED_REPL packet and returns a
+    # hash with one key, :md5, which references the computed hash.
+    def parse_md5_packet(data)
+      md5 = ""
+
+      if !data.empty?
+        md5 = data.read_string
+      end
+
+      { :md5 => md5 }
+    end
+
+    # Parses the given "check-file" FXP_EXTENDED_REPL packet and returns a hash
+    # with two keys, :algo, which references the hash algorithm used and
+    # :hashes which references the computed hashes.
+    def parse_hash_packet(data)
+      hashes = []
+
+      algo = data.read_string
+      size = case algo
+        when "md5"    then 128
+        when "sha256" then 256
+        when "sha384" then 284
+        when "sha512" then 512
+        else raise NotImplementedError, "unsupported algorithm: #{algo}"
+      end
+
+      while !data.eof? do
+        hashes << data.read(size)
+      end
+
+      { :algo => algo, :hashes => hashes }
+    end
+
+    # Parses the given "home-directory" FXP_EXTENDED_REPL packet and returns a
+    # hash with one key, :home, which references the home directory returned by
+    # the server.
+    def parse_home_packet(data)
+      { :home => data.read_string }
+    end
+
+    # Parses the given FXP_EXTENDED_REPL packet and returns a hash, with
+    # :extension key, which references SFTP extension and the associated keys
+    def parse_extented_reply_packet(packet)
+       packet.read_string do |extension|
+         data = packet.remainder_as_buffer
+         parsed_packet = case extension
+           when "md5-hash"       then parse_md5_packet(data)
+           when "check-file"     then parse_hash_packet(data)
+           when "home-directory" then parse_home_packet(data)
+           else raise NotImplementedError, "unknown packet type: #{extension}"
+         end
+       end
+
+      { :extension => extension }.merge(parsed_packet)
+    end
+
+    # Sends a FXP_EXTENDED packet to the server to request MD5 checksum
+    # computation for file (or portion of file) obtained on the given +handle+,
+    # for the given byte +offset+ and +length+. The +quick_hash+ parameter is
+    # the hash over the first 2048 bytes of the data. It allows the server to
+    # quickly check if it is worth the resources to hash a big file.
+    def md5(handle, offset, length, quick_hash)
+      send_request(FXP_EXTENDED, :string, "md5-hash-handle", :int64, offset, :int64, length, :string, quick_hash)
+    end
+
+    # Sends a FXP_EXTENDED packet to the server to request checksum computation
+    # for file (or portion of file) obtained on the given +handle+, for the
+    # given byte +offset+ and +length+. The +block_size+ parameter is used to
+    # compute over every +block_size+ block in the file. If the +block_size+ is
+    # 0, then only one hash, over the entire range, is made.
+    def hash(handle, offset, length, block_size=0)
+      if block_size != 0 && block_size < 255
+        block_size = 256
+      end
+      send_request(FXP_EXTENDED, :string, "check-file-handle", :string, handle, :string, "md5,sha256,sha384,sha512", :int64, offset, :int64, length, :long, block_size)
+    end
+
+    # Sends a FXP_EXTENDED packet to the server to request disk space availability
+    # for the given +path+ location.
+    def space_available(path)
+      send_request(FXP_EXTENDED, :string, "space-available", :string, path)
+    end
+
+    # Sends a FXP_EXTENDED packet to the server to request home directory
+    # for the given +username+.
+    def home(username)
+      send_request(FXP_EXTENDED, :string, "home-directory", :string, username)
+    end
+
+  end
+
+end; end; end; end

--- a/lib/net/sftp/protocol/base.rb
+++ b/lib/net/sftp/protocol/base.rb
@@ -26,11 +26,12 @@ module Net; module SFTP; module Protocol
     # (the keys in the hash are packet-type specific).
     def parse(packet)
       case packet.type
-      when FXP_STATUS then parse_status_packet(packet)
-      when FXP_HANDLE then parse_handle_packet(packet)
-      when FXP_DATA   then parse_data_packet(packet)
-      when FXP_NAME   then parse_name_packet(packet)
-      when FXP_ATTRS  then parse_attrs_packet(packet)
+      when FXP_STATUS          then parse_status_packet(packet)
+      when FXP_HANDLE          then parse_handle_packet(packet)
+      when FXP_DATA            then parse_data_packet(packet)
+      when FXP_NAME            then parse_name_packet(packet)
+      when FXP_ATTRS           then parse_attrs_packet(packet)
+      when FXP_EXTENDED_REPLY  then parse_extented_reply_packet(packet)
       else raise NotImplementedError, "unknown packet type: #{packet.type}"
       end
     end

--- a/test/protocol/06/test_extended.rb
+++ b/test/protocol/06/test_extended.rb
@@ -1,0 +1,50 @@
+require 'common'
+require 'protocol/06/test_base'
+
+class Protocol::V06::TestExtended < Protocol::V06::TestBase
+
+  def setup
+    @session = stub('session', :logger => nil)
+    @base = driver.new(@session)
+  end
+
+  def test_version
+    assert_equal 6, @base.version
+  end
+
+  def test_md5_should_send_md5_hash_packet
+    @session.expects(:send_packet).with(FXP_EXTENDED, :long, 0, :string, "md5-hash-handle", :int64, 112233, :int64, 445566, :string, "ABCDEF")
+    assert_equal 0, @base.md5("test", 112233, 445566, "ABCDEF")
+  end
+
+  def test_hash_should_send_hash_packet
+    @session.expects(:send_packet).with(FXP_EXTENDED, :long, 0, :string, "check-file-handle", :string, "test", :string, "md5,sha256,sha384,sha512", :int64, 112233, :int64, 445566, :long, 0)
+    assert_equal 0, @base.hash("test", 112233, 445566)
+  end
+
+  def test_hash_should_send_hash_packet_with_block_size
+    @session.expects(:send_packet).with(FXP_EXTENDED, :long, 0, :string, "check-file-handle", :string, "test", :string, "md5,sha256,sha384,sha512", :int64, 112233, :int64, 445566, :long, 256)
+    assert_equal 0, @base.hash("test", 112233, 445566, 123)
+  end
+
+  def test_hash_should_send_hash_packet_with_valid_block_size
+    @session.expects(:send_packet).with(FXP_EXTENDED, :long, 0, :string, "check-file-handle", :string, "test", :string, "md5,sha256,sha384,sha512", :int64, 112233, :int64, 445566, :long, 256)
+    assert_equal 0, @base.hash("test", 112233, 445566, -1)
+  end
+
+  def test_space_available_should_send_space_available_packet
+    @session.expects(:send_packet).with(FXP_EXTENDED, :long, 0, :string, "space-available", :string, "/var/log/Xorg.0.log")
+    assert_equal 0, @base.space_available("/var/log/Xorg.0.log")
+  end
+
+  def test_home_should_send_home_directory_packet
+    @session.expects(:send_packet).with(FXP_EXTENDED, :long, 0, :string, "home-directory", :string, "test")
+    assert_equal 0, @base.home("test")
+  end
+
+  private
+
+    def driver
+      Net::SFTP::Protocol::V06::Extended
+    end
+end

--- a/test/test_protocol.rb
+++ b/test/test_protocol.rb
@@ -1,12 +1,18 @@
 require 'common'
 
 class ProtocolTest < Net::SFTP::TestCase
-  1.upto(6) do |version|
+  1.upto(5) do |version|
     define_method("test_load_version_#{version}_should_return_v#{version}_driver") do
       session = stub('session', :logger => nil)
       driver = Net::SFTP::Protocol.load(session, version)
       assert_instance_of Net::SFTP::Protocol.const_get("V%02d" % version)::Base, driver
     end
+  end
+
+  def test_load_version_6_should_return_v6_driver
+    session = stub('session', :logger => nil)
+    driver = Net::SFTP::Protocol.load(session, 6)
+    assert_instance_of Net::SFTP::Protocol.const_get("V06")::Extended, driver
   end
 
   def test_load_version_7_should_be_unsupported


### PR DESCRIPTION
Please find a pull request regarding https://tools.ietf.org/html/draft-ietf-secsh-filexfer-09 [9.  Extensions]

Handle SFTP V6 extensions commands
 - md5-hash-handle
 - check-file-handle
 - space-available
 - home-directory

Test results under `ruby 2.3.1p112 (2016-04-26) [x86_64-linux-gnu]` + `net-ssh-4.1.0` follows

```
ruby2.3 -Itest test/protocol/06/test_extended.rb -v
Loaded suite test/protocol/06/test_extended
Started
Net::SFTP::TestCase: 
  default_test:								.: (0.002273)
  Protocol::V01::TestBase: 
    test_block_should_raise_not_implemented_error:			.: (0.000703)
    test_close_should_send_close_packet:					.: (0.000470)
    test_fsetstat_should_translate_hash_to_attributes_and_send_fsetstat_packet:.: (0.000602)
    test_fstat_should_ignore_flags_parameter:				.: (0.000428)
    test_fstat_should_send_fstat_packet:					.: (0.000404)
    test_link_should_raise_not_implemented_error:			.: (0.000323)
    test_lstat_should_ignore_flags_parameter:				.: (0.000443)
    test_lstat_should_send_lstat_packet:					.: (0.000404)
    test_mkdir_should_translate_hash_to_attributes_and_send_mkdir_packet:.: (0.000490)
    test_open_with_a_plus_should_translate_correctly:			.: (0.000516)
    test_open_with_a_should_translate_correctly:				.: (0.000462)
    test_open_with_attributes_converts_hash_to_attribute_packet:		.: (0.000463)
    test_open_with_numeric_flag_should_accept_IO_constants:		.: (0.000530)
    test_open_with_r_plus_should_translate_correctly:			.: (0.000488)
    test_open_with_r_should_translate_correctly:				.: (0.000527)
    test_open_with_rb_should_translate_correctly:			.: (0.000527)
    test_open_with_w_plus_should_translate_correctly:			.: (0.000552)
    test_open_with_w_should_translate_correctly:				.: (0.000474)
    test_opendir_should_send_opendir_packet:				.: (0.000458)
    test_parse_attrs_packet_should_use_correct_attributes_class:		.: (0.000679)
    test_parse_data_packet_should_read_string_from_packet_and_return_data_in_hash:.: (0.000380)
    test_parse_handle_packet_should_read_string_from_packet_and_return_handle_in_hash:.: (0.000332)
    test_parse_name_packet_should_use_correct_name_class:		.: (0.000558)
    test_parse_status_packet_should_read_long_from_packet_and_return_code_in_hash:.: (0.000318)
    test_read_should_send_read_packet:					.: (0.000449)
    test_readdir_should_send_readdir_packet:				.: (0.000472)
    test_readlink_should_raise_not_implemented_error:			.: (0.000371)
    test_realpath_should_send_realpath_packet:				.: (0.000413)
    test_remove_should_send_remove_packet:				.: (0.000474)
    test_rename_should_raise_not_implemented_error:			.: (0.000338)
    test_rmdir_should_send_rmdir_packet:					.: (0.000407)
    test_setstat_should_translate_hash_to_attributes_and_send_setstat_packet:.: (0.000514)
    test_stat_should_ignore_flags_parameter:				.: (0.000419)
    test_stat_should_send_stat_packet:					.: (0.000439)
    test_symlink_should_raise_not_implemented_error:			.: (0.000349)
    test_unblock_should_raise_not_implemented_error:			.: (0.000435)
    test_version:							.: (0.000294)
    test_write_should_send_write_packet:					.: (0.000426)
    Protocol::V02::TestBase: 
      test_rename_should_ignore_flags_parameter:				.: (0.000739)
      test_rename_should_send_rename_packet:				.: (0.000465)
      test_version:							.: (0.000315)
      Protocol::V03::TestBase: 
        test_readlink_should_send_readlink_packet:			.: (0.000723)
        test_symlink_should_send_symlink_packet:				.: (0.000491)
        test_version:							.: (0.000333)
        Protocol::V04::TestBase: 
          test_fstat_should_send_fstat_packet:				.: (0.000852)
          test_fstat_with_custom_flags_should_send_fstat_packet_with_given_flags:.: (0.000646)
          test_lstat_should_send_lstat_packet:				.: (0.000659)
          test_lstat_with_custom_flags_should_send_lstat_packet_with_given_flags:.: (0.000633)
          test_parse_attrs_packet_should_use_correct_attributes_class:	.: (0.000752)
          test_parse_name_packet_should_use_correct_name_class:		.: (0.000591)
          test_stat_should_send_stat_packet:				.: (0.000538)
          test_stat_with_custom_flags_should_send_stat_packet_with_given_flags:.: (0.000453)
          test_version:							.: (0.000327)
          Protocol::V05::TestBase: 
            test_open_with_a_plus_should_translate_correctly:		.: (0.000949)
            test_open_with_a_should_translate_correctly:			.: (0.000544)
            test_open_with_attributes_converts_hash_to_attribute_packet:	.: (0.000563)
            test_open_with_numeric_flag_should_accept_IO_constants:	.: (0.000600)
            test_open_with_r_plus_should_translate_correctly:		.: (0.000541)
            test_open_with_r_should_translate_correctly:			.: (0.000523)
            test_open_with_rb_should_translate_correctly:		.: (0.000546)
            test_open_with_w_plus_should_translate_correctly:		.: (0.000529)
            test_open_with_w_should_translate_correctly:			.: (0.000558)
            test_rename_should_send_rename_packet:			.: (0.000520)
            test_rename_with_flags_should_send_rename_packet_with_flags:	.: (0.000668)
            test_version:						.: (0.000971)
            Protocol::V06::TestBase: 
              test_block_should_send_block_packet:			.: (0.000914)
              test_link_should_send_link_packet:				.: (0.000508)
              test_parse_attrs_packet_should_use_correct_attributes_class:.: (0.000733)
              test_symlink_should_send_link_packet_as_symlink:		.: (0.000491)
              test_unblock_should_send_unblock_packet:			.: (0.000477)
              test_version:						.: (0.000325)
              Protocol::V06::TestExtended: 
                test_hash_should_send_hash_packet:			.: (0.000797)
                test_hash_should_send_hash_packet_with_block_size:	.: (0.000553)
                test_hash_should_send_hash_packet_with_valid_block_size:	.: (0.000604)
                test_home_should_send_home_directory_packet:		.: (0.000521)
                test_md5_should_send_md5_hash_packet:			.: (0.000547)
                test_space_available_should_send_space_available_packet:	.: (0.000572)
                test_version:						.: (0.000401)

Finished in 0.051579164 seconds.
------------------------------------------------------------------------------------------------
79 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------
1531.63 tests/s, 2908.15 assertions/s
```