### PR TITLE
Make file operation work with CSV library

### DIFF
--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -115,8 +115,8 @@ module Net; module SFTP; module Operations
 
     # Same as #gets, but raises EOFError if EOF is encountered before any
     # data could be read.
-    def readline(sep_string=$/)
-      line = gets(sep_string)
+    def readline(sep_or_limit=$/, limit=Float::INFINITY)
+      line = gets(sep_or_limit, limit)
       raise EOFError if line.nil?
       return line
     end

--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -82,7 +82,15 @@ module Net; module SFTP; module Operations
     # returns the bytes read (including +sep_string+). If +sep_string+ is
     # omitted, it defaults to +$/+. If EOF is encountered before any data
     # could be read, #gets will return +nil+.
-    def gets(sep_string=$/)
+    def gets(sep_or_limit=$/, limit=Float::INFINITY)
+      if sep_or_limit.is_a? Integer
+        sep_string = $/
+        lim = sep_or_limit
+      else
+        sep_string = sep_or_limit
+        lim = limit
+      end
+
       delim = if sep_string.length == 0
         "#{$/}#{$/}"
       else
@@ -92,7 +100,7 @@ module Net; module SFTP; module Operations
       loop do
         at = @buffer.index(delim)
         if at
-          offset = at + delim.length
+          offset = [at + delim.length, lim].min
           @pos += offset
           line, @buffer = @buffer[0,offset], @buffer[offset..-1]
           return line

--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -106,6 +106,10 @@ module Net; module SFTP; module Operations
           @pos += offset
           line, @buffer = @buffer[0,offset], @buffer[offset..-1]
           return line
+        elsif lim < @buffer.length
+          @pos += lim
+          line, @buffer = @buffer[0,lim], @buffer[lim..-1]
+          return line
         elsif !fill
           return nil if @buffer.empty?
           @pos += @buffer.length

--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -127,6 +127,14 @@ module Net; module SFTP; module Operations
       return line
     end
 
+    # Resets position to beginning of file
+    def rewind
+      @pos      = 0
+      @real_pos = 0
+      @real_eof = false
+      @buffer   = ""
+    end
+
     # Writes the given data to the stream, incrementing the file position and
     # returning the number of bytes written.
     def write(data)

--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -93,14 +93,14 @@ module Net; module SFTP; module Operations
         lim = limit
       end
 
-      delim = if sep_string.length == 0
+      delim = if sep_string && sep_string.length == 0
         "#{$/}#{$/}"
       else
         sep_string
       end
 
       loop do
-        at = @buffer.index(delim)
+        at = @buffer.index(delim) if delim
         if at
           offset = [at + delim.length, lim].min
           @pos += offset

--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -81,7 +81,9 @@ module Net; module SFTP; module Operations
     # Reads up to the next instance of +sep_string+ in the stream, and
     # returns the bytes read (including +sep_string+). If +sep_string+ is
     # omitted, it defaults to +$/+. If EOF is encountered before any data
-    # could be read, #gets will return +nil+.
+    # could be read, #gets will return +nil+. If the first argument is an
+    # integer, or optional second argument is given, the returning string
+    # would not be longer than the given value in bytes.
     def gets(sep_or_limit=$/, limit=Float::INFINITY)
       if sep_or_limit.is_a? Integer
         sep_string = $/

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -91,6 +91,12 @@ class FileOperationsTest < Net::SFTP::TestCase
     assert @file.eof?
   end
 
+  def test_gets_when_nil_delimiter_should_fread_to_EOF
+    @sftp.expects(:read!).times(2).returns("hello world\ngoodbye world\n\nfarewell!\n", nil)
+    assert_equal "hello world\ngoodbye world\n\nfarewell!\n", @file.gets(nil)
+    assert @file.eof?
+  end
+
   def test_gets_with_integer_argument_should_read_number_of_bytes
     @sftp.expects(:read!).returns("hello world\ngoodbye world\n\nfarewell!\n")
     assert_equal "hello w", @file.gets(7)
@@ -109,6 +115,11 @@ class FileOperationsTest < Net::SFTP::TestCase
   def test_gets_when_no_such_delimiter_exists_in_stream_but_limit_provided_should_read_to_limit
     @sftp.expects(:read!).returns("hello world\ngoodbye world\n\nfarewell!\n")
     assert_equal "hello w", @file.gets("z", 7)
+  end
+
+  def test_gets_when_nil_delimiter_and_limit_provided_should_read_to_limit
+    @sftp.expects(:read!).returns("hello world\ngoodbye world\n\nfarewell!\n")
+    assert_equal "hello w", @file.gets(nil, 7)
   end
 
   def test_gets_at_EOF_should_return_nil

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -91,6 +91,21 @@ class FileOperationsTest < Net::SFTP::TestCase
     assert @file.eof?
   end
 
+  def test_gets_with_integer_argument_should_read_number_of_bytes
+    @sftp.expects(:read!).returns("hello world\ngoodbye world\n\nfarewell!\n")
+    assert_equal "hello w", @file.gets(7)
+  end
+
+  def test_gets_with_delimiter_and_limit_should_read_to_delimiter_if_less_than_limit
+    @sftp.expects(:read!).returns("hello world\ngoodbye world\n\nfarewell!\n")
+    assert_equal "hello w", @file.gets("w", 11)
+  end
+
+  def test_gets_with_delimiter_and_limit_should_read_to_limit_if_less_than_delimiter
+    @sftp.expects(:read!).returns("hello world\ngoodbye world\n\nfarewell!\n")
+    assert_equal "hello", @file.gets("w", 5)
+  end
+
   def test_gets_at_EOF_should_return_nil
     @sftp.expects(:read!).returns(nil)
     assert_nil @file.gets

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -133,6 +133,15 @@ class FileOperationsTest < Net::SFTP::TestCase
     assert_raises(EOFError) { @file.readline }
   end
 
+  def test_rewind_should_reset_to_beginning_of_file
+    @sftp.expects(:read!).times(2).returns("hello world", nil)
+    @file.read
+    assert @file.eof?
+    @file.rewind
+    assert !@file.eof?
+    assert_equal 0, @file.pos
+  end
+
   def test_write_should_write_data_and_increment_pos_and_return_data_length
     @sftp.expects(:write!).with("handle", 0, "hello world")
     assert_equal 11, @file.write("hello world")

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -106,6 +106,11 @@ class FileOperationsTest < Net::SFTP::TestCase
     assert_equal "hello", @file.gets("w", 5)
   end
 
+  def test_gets_when_no_such_delimiter_exists_in_stream_but_limit_provided_should_read_to_limit
+    @sftp.expects(:read!).returns("hello world\ngoodbye world\n\nfarewell!\n")
+    assert_equal "hello w", @file.gets("z", 7)
+  end
+
   def test_gets_at_EOF_should_return_nil
     @sftp.expects(:read!).returns(nil)
     assert_nil @file.gets


### PR DESCRIPTION
This is to fix the issue reported in https://github.com/net-ssh/net-sftp/issues/65.

The two missing pieces of the IO-like object needed by the CSV library are a `limit` argument for the `#gets`method and a `#rewind` method. I've attempted to match the interface described by Ruby's [IO class](https://ruby-doc.org/core-2.5.1/IO.html).

The flexibility of arguments that `#gets` accepts makes for some messy conditional code. Hopefully the changes I've made are clear. According to the docs, the first argument can have the following behavior:
- Separator string: read until separator is found
- Zero-length string: read until end of paragraph
- Integer: read N bytes
- Nil: read until end of file

These can also be paired with a second `limit` argument. 

I've added some tests and also tested with the following code:

```ruby
require 'csv'

$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
require 'net/sftp'

Net::SFTP.start("my_hostname", "my_username", password: "my_password") do |sftp|
  stream = sftp.file.open("my_filepath.csv")
  CSV.new(stream).each { |row| puts row }
end
```


