### PR TITLE
Update to net-ssh 5.0.2 improves performance; fix tests

### DIFF
--- a/net-sftp.gemspec
+++ b/net-sftp.gemspec
@@ -31,16 +31,16 @@ Gem::Specification.new do |spec|
     spec.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      spec.add_runtime_dependency(%q<net-ssh>, [">= 2.6.5", "< 5.0.0"])
+      spec.add_runtime_dependency(%q<net-ssh>, [">= 2.6.5", "< 6.0.0"])
       spec.add_development_dependency(%q<test-unit>, [">= 0"])
       spec.add_development_dependency(%q<mocha>, [">= 0"])
     else
-      spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 5.0.0"])
+      spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 6.0.0"])
       spec.add_dependency(%q<test-unit>, [">= 0"])
       spec.add_dependency(%q<mocha>, [">= 0"])
     end
   else
-    spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 5.0.0"])
+    spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 6.0.0"])
     spec.add_dependency(%q<test-unit>, [">= 0"])
     spec.add_dependency(%q<mocha>, [">= 0"])
   end

--- a/test/test_upload.rb
+++ b/test/test_upload.rb
@@ -207,7 +207,7 @@ class UploadTest < Net::SFTP::TestCase
 
     def expect_file(path, data)
       File.stubs(:directory?).with(path).returns(false)
-      File.stubs(:exists?).with(path).returns(true)
+      File.stubs(:exist?).with(path).returns(true)
       file = StringIO.new(data)
       file.stubs(:stat).returns(stub("stat", :size => data.length))
       File.stubs(:open).with(path, "rb").returns(file)


### PR DESCRIPTION
Fixes slow uploads, in our case from 200 KB/s to 8000 MB/s, as discussed in #54.
Also tests were failing for a few commits; fixed.