### PR TITLE
Add #size and #rewind to Net::SFTP::Operations::File

### DIFF
--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -131,6 +131,11 @@ module Net; module SFTP; module Operations
       nil
     end
 
+    # Returns the size of the file from stats
+    def size
+      stat.size
+    end
+
     # Writes each argument to the stream, appending a newline to any item
     # that does not already end in a newline. Array arguments are flattened.
     def puts(*items)

--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -131,9 +131,12 @@ module Net; module SFTP; module Operations
       nil
     end
 
-    # Returns the size of the file from stats
     def size
       stat.size
+    end
+
+    def rewind
+      self.pos = 0
     end
 
     # Writes each argument to the stream, appending a newline to any item

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -156,4 +156,10 @@ class FileOperationsTest < Net::SFTP::TestCase
     @sftp.expects(:fstat!).with("handle").returns(stat)
     assert_equal stat, @file.stat
   end
+
+  def test_size_should_return_size_from_stat
+    stat = stub(size: 1024)
+    @sftp.expects(:fstat!).with("handle").returns(stat)
+    assert_equal 1024, @file.size
+  end
 end

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -162,4 +162,14 @@ class FileOperationsTest < Net::SFTP::TestCase
     @sftp.expects(:fstat!).with("handle").returns(stat)
     assert_equal 1024, @file.size
   end
+
+  def test_rewind
+    @sftp.expects(:write!).with("handle", 0, "hello world\n")
+    @sftp.expects(:read!).with("handle", 12, 8192).returns("hello world\n")
+    @sftp.expects(:read!).with("handle", 0, 8192).returns("hello world\n")
+    @file.puts "hello world\n"
+    assert_equal "hello", @file.read(5)
+    @file.rewind
+    assert_equal "hello world", @file.read(11)
+  end
 end


### PR DESCRIPTION
Per #77, this PR adds a `#size` and `#rewind` method to `Net::SFTP::Operations::File`. This should allow clients, such as the AWS Ruby SDK, to perform stream-like operations on an SFTP file.