### PR TITLE
Remove duplicate Net::SFTP::Operations::File#rewind

### DIFF
--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -127,14 +127,6 @@ module Net; module SFTP; module Operations
       return line
     end
 
-    # Resets position to beginning of file
-    def rewind
-      @pos      = 0
-      @real_pos = 0
-      @real_eof = false
-      @buffer   = ""
-    end
-
     # Writes the given data to the stream, incrementing the file position and
     # returning the number of bytes written.
     def write(data)
@@ -157,6 +149,7 @@ module Net; module SFTP; module Operations
       stat.size
     end
 
+    # Resets position to beginning of file
     def rewind
       self.pos = 0
     end

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -142,6 +142,16 @@ class FileOperationsTest < Net::SFTP::TestCase
     assert_equal 0, @file.pos
   end
 
+  def test_rewind
+    @sftp.expects(:write!).with("handle", 0, "hello world\n")
+    @sftp.expects(:read!).with("handle", 12, 8192).returns("hello world\n")
+    @sftp.expects(:read!).with("handle", 0, 8192).returns("hello world\n")
+    @file.puts "hello world\n"
+    assert_equal "hello", @file.read(5)
+    @file.rewind
+    assert_equal "hello world", @file.read(11)
+  end
+
   def test_write_should_write_data_and_increment_pos_and_return_data_length
     @sftp.expects(:write!).with("handle", 0, "hello world")
     assert_equal 11, @file.write("hello world")
@@ -201,15 +211,5 @@ class FileOperationsTest < Net::SFTP::TestCase
     stat = stub(size: 1024)
     @sftp.expects(:fstat!).with("handle").returns(stat)
     assert_equal 1024, @file.size
-  end
-
-  def test_rewind
-    @sftp.expects(:write!).with("handle", 0, "hello world\n")
-    @sftp.expects(:read!).with("handle", 12, 8192).returns("hello world\n")
-    @sftp.expects(:read!).with("handle", 0, 8192).returns("hello world\n")
-    @file.puts "hello world\n"
-    assert_equal "hello", @file.read(5)
-    @file.rewind
-    assert_equal "hello world", @file.read(11)
   end
 end


### PR DESCRIPTION
Separate `#rewind` methods were added by two PRs: https://github.com/net-ssh/net-sftp/pull/81 and https://github.com/net-ssh/net-sftp/pull/83.

 I kept the latter one because it resuses an existing method instead of duplicating code. I also grouped the tests together.

```ruby
def rewind
  @pos      = 0
  @real_pos = 0
  @real_eof = false
  @buffer   = ""
end
```
vs.

```ruby
def rewind
  self.pos = 0
end
```