### PR TITLE
More detailed logging

### DIFF
--- a/lib/net/sftp/session.rb
+++ b/lib/net/sftp/session.rb
@@ -829,7 +829,7 @@ module Net; module SFTP
       # request.
       def request(type, *args, &callback)
         request = Request.new(self, type, protocol.send(type, *args), &callback)
-        info { "sending #{type} packet (#{request.id})" }
+        info { "sending #{type} packet (id #{request.id}) args: #{args}" }
         pending_requests[request.id] = request
       end
 
@@ -904,7 +904,11 @@ module Net; module SFTP
           input.consume!
           @packet_length = nil
 
-          debug { "received sftp packet #{packet.type} len #{packet.length}" }
+          readable_type = Net::SFTP::Constants::PacketTypes.constants.find do |constant|
+            Net::SFTP::Constants::PacketTypes.const_get(constant) == packet.type
+          end
+
+          debug { "received sftp packet #{packet.type} (readable_type) len #{packet.length}" }
 
           if packet.type == FXP_VERSION
             do_version(packet)


### PR DESCRIPTION
Sample output:
`I, [2018-12-17T21:45:12.307225 #238773]  INFO -- net.sftp.session[3fafd1c2e7e4]: sending open packet (id 0) args: ["test.txt", "w", {}]`
`D, [2018-12-17T21:45:12.399133 #238773] DEBUG -- net.sftp.session[3fafd1c2e7e4]: received sftp packet FXP_STATUS len 29`