### PR TITLE
Initialize Session#pending_requests on construction

### DIFF
--- a/lib/net/sftp/session.rb
+++ b/lib/net/sftp/session.rb
@@ -76,11 +76,12 @@ module Net; module SFTP
     #   sftp = Net::SFTP::Session.new(ssh)
     #   sftp.loop { sftp.opening? }
     def initialize(session, version = nil, &block)
-      @session    = session
-      @version    = version
-      @input      = Net::SSH::Buffer.new
-      self.logger = session.logger
-      @state      = :closed
+      @session          = session
+      @version          = version
+      @input            = Net::SSH::Buffer.new
+      self.logger       = session.logger
+      @state            = :closed
+      @pending_requests = {}
 
       connect(&block)
     end
@@ -934,7 +935,6 @@ module Net; module SFTP
         end
 
         @protocol = Protocol.load(self, negotiated_version)
-        @pending_requests = {}
 
         @state = :open
         @on_ready.each { |callback| callback.call(self) }


### PR DESCRIPTION
In some circumstances, it was being referenced before being initialized.

Fixes #35.

I'm running into this too on occasion too. I'm not yet sure exactly what the required conditions are to trigger it, so it's hard to write a test, but happy to take input there. At least the existing suite gives some confidence that this doesn't break anything.