### PR TITLE
Allow to set protocol version via Net::SFTP.start

### DIFF
--- a/lib/net/sftp.rb
+++ b/lib/net/sftp.rb
@@ -32,8 +32,8 @@ module Net
     # - The Net::SSH connection options (see Net::SSH for more information)
     # - The Net::SFTP connection options (only :version is supported, to let you 
     #   set the SFTP protocol version to be used)
-    def self.start(host, user, options={}, sftp_options={}, &block)
-      session = Net::SSH.start(host, user, options)
+    def self.start(host, user, ssh_options={}, sftp_options={}, &block)
+      session = Net::SSH.start(host, user, ssh_options)
       # We only use a single option here, but this leaves room for more later
       # without breaking the external API.
       version = sftp_options.fetch(:version, nil)

--- a/lib/net/sftp.rb
+++ b/lib/net/sftp.rb
@@ -27,9 +27,12 @@ module Net
     #   Net::SFTP.start("localhost", "user") do |sftp|
     #     sftp.upload! "/local/file.tgz", "/remote/file.tgz"
     #   end
-    def self.start(host, user, options={}, &block)
+    def self.start(host, user, options={}, sftp_options={}, &block)
       session = Net::SSH.start(host, user, options)
-      sftp = Net::SFTP::Session.new(session, &block).connect!
+      # We only use a single option here, but this leaves room for more later
+      # without breaking the external API.
+      version = sftp_options.fetch(:version, nil)
+      sftp = Net::SFTP::Session.new(session, version, &block).connect!
 
       if block_given?
         sftp.loop

--- a/lib/net/sftp.rb
+++ b/lib/net/sftp.rb
@@ -27,6 +27,11 @@ module Net
     #   Net::SFTP.start("localhost", "user") do |sftp|
     #     sftp.upload! "/local/file.tgz", "/remote/file.tgz"
     #   end
+    #
+    # Extra parameters can be passed:
+    # - The Net::SSH connection options (see Net::SSH for more information)
+    # - The Net::SFTP connection options (only :version is supported, to let you 
+    #   set the SFTP protocol version to be used)
     def self.start(host, user, options={}, sftp_options={}, &block)
       session = Net::SSH.start(host, user, options)
       # We only use a single option here, but this leaves room for more later

--- a/test/test_start.rb
+++ b/test/test_start.rb
@@ -9,11 +9,26 @@ class StartTest < Net::SFTP::TestCase
     sftp = mock('sftp')
     # TODO: figure out how to verify a block is passed, and call it later.
     # I suspect this is hard to do properly with mocha.
-    Net::SFTP::Session.expects(:new).with(ssh).returns(sftp)
+    Net::SFTP::Session.expects(:new).with(ssh, nil).returns(sftp)
     sftp.expects(:connect!).returns(sftp)
     sftp.expects(:loop)
     
     Net::SFTP.start('host', 'user') do
+      # NOTE: currently not called!
+    end
+  end
+  
+  def test_with_block_and_options
+    ssh = mock('ssh')
+    ssh.expects(:close)
+    Net::SSH.expects(:start).with('host', 'user', auth_methods: ["password"]).returns(ssh)
+
+    sftp = mock('sftp')
+    Net::SFTP::Session.expects(:new).with(ssh, 3).returns(sftp)
+    sftp.expects(:connect!).returns(sftp)
+    sftp.expects(:loop)
+    
+    Net::SFTP.start('host', 'user', {auth_methods: ["password"]}, {version: 3}) do
       # NOTE: currently not called!
     end
   end

--- a/test/test_start.rb
+++ b/test/test_start.rb
@@ -1,0 +1,20 @@
+require 'common'
+
+class StartTest < Net::SFTP::TestCase
+  def test_with_block
+    ssh = mock('ssh')
+    ssh.expects(:close)
+    Net::SSH.expects(:start).with('host', 'user', {}).returns(ssh)
+
+    sftp = mock('sftp')
+    # TODO: figure out how to verify a block is passed, and call it later.
+    # I suspect this is hard to do properly with mocha.
+    Net::SFTP::Session.expects(:new).with(ssh).returns(sftp)
+    sftp.expects(:connect!).returns(sftp)
+    sftp.expects(:loop)
+    
+    Net::SFTP.start('host', 'user') do
+      # NOTE: currently not called!
+    end
+  end
+end


### PR DESCRIPTION
As discussed [here](https://github.com/net-ssh/net-sftp/issues/92#issuecomment-619503683), this PR ensures one can override the protocol version with the higher-level API (`Net::SFTP.start`).

~~Please do not merge yet, as I need to do a bit of testing on a real project.~~ I did limited testing on a server, seems OK at this point.

### On tests

`Net::SFTP.start` code was not covered (afaik, based on `simplecov` output) by tests. I added some tests which are far from perfect (the fact that the provided block must be called is not tested, for instance, and the tests are verbose), but nonetheless enough to let me refactor and support the new feature.

Mocha is apparently not letting me intercept a call with a block and capture it.

I saw that some testing facilities are available in other tests and also in `Net::SSH`, so maybe it is possible to do a better job here.