### PR TITLE
Fix multibyte string write

### DIFF
--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -132,9 +132,9 @@ module Net; module SFTP; module Operations
     def write(data)
       data = data.to_s
       sftp.write!(handle, @real_pos, data)
-      @real_pos += data.length
+      @real_pos += data.bytes.length
       @pos = @real_pos
-      data.length
+      data.bytes.length
     end
 
     # Writes each argument to the stream. If +$\+ is set, it will be written

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -165,6 +165,12 @@ class FileOperationsTest < Net::SFTP::TestCase
     assert_equal 26, @file.pos
   end
 
+  def test_write_should_write_mutlibyte_string_data_and_increment_pos_and_return_data_length
+    @sftp.expects(:write!).with("handle", 0, "hello world, 你好，世界")
+    assert_equal 28, @file.write("hello world, 你好，世界")
+    assert_equal 28, @file.pos
+  end
+
   def test_print_with_no_arguments_should_write_nothing_if_dollar_bslash_is_nil
     assert_nil $\
     @sftp.expects(:write!).never


### PR DESCRIPTION
Fixes writing of string with multibyte UTF8 characters. The position was calculated based on string size, which was incorrect since position should be in bytes.

The result was that when using file.puts for streaming, data would get overwritten (since the calculated position was too small).

Added test with 3 byte chinese characters.