### PR TITLE
Update cert URL and filename on README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -76,8 +76,8 @@ However, in order to be sure the code you're installing hasn't been tampered wit
 
     # Add the public key as a trusted certificate
     # (You only need to do this once)
-    $ curl -O https://raw.github.com/net-ssh/net-ssh/master/gem-public_cert.pem
-    $ gem cert --add gem-public_cert.pem
+    $ curl -O https://raw.githubusercontent.com/net-ssh/net-sftp/master/net-sftp-public_cert.pem
+    $ gem cert --add net-sftp-public_cert.pem
 
 Then, when install the gem, do so with high security:
 


### PR DESCRIPTION
The filename of the public key has changed in the repo (gem-public_cert.pem to net-sftp-public_cert.pem).  Additionally, raw.github.com redirects (301) to raw.githubusercontent.com, so either the URL needs to be updated or the follow redirects option (-L) needs to be passed to curl.