### PR TITLE
Missing Net::SFTP::Operations::File#<<

### DIFF
--- a/lib/net/sftp/operations/file.rb
+++ b/lib/net/sftp/operations/file.rb
@@ -137,6 +137,8 @@ module Net; module SFTP; module Operations
       data.bytes.length
     end
 
+    alias << write
+
     # Writes each argument to the stream. If +$\+ is set, it will be written
     # after all arguments have been written.
     def print(*items)

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -158,6 +158,12 @@ class FileOperationsTest < Net::SFTP::TestCase
     assert_equal 11, @file.pos
   end
 
+  def test_double_less_should_write_data_and_increment_pos_and_return_data_length
+    @sftp.expects(:write!).with("handle", 0, "hello world")
+    assert_equal 11, @file << ("hello world")
+    assert_equal 11, @file.pos
+  end
+
   def test_write_after_pos_assignment_should_write_at_position
     @sftp.expects(:write!).with("handle", 15, "hello world")
     @file.pos = 15


### PR DESCRIPTION
Alias Net::SFTP::Operations::File#<< to Net::SFTP::Operations::File#write
See Issue #123 