### PR TITLE
CI: drop support for EOL Rubies (< 2.7), add support for Ruby 3.4, shift jRuby support from 9.2/9.3 -> 9.3/9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
           - "3.0"
           - 3.1
           - 3.2
-          - truffleruby-22
+          - 3.3
+          - 3.4
           - truffleruby-23
+          - truffleruby-24
         flaky: [false]
         include:
           - ruby-version: "head"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-${{ hashFiles('../../Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,5 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
-      - name: Bundle install
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install -j $(getconf _NPROCESSORS_ONLN) --retry 3
-
       - name: Run Tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,34 +2,51 @@ name: CI
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.flaky }}
+    name: "Tests: Ruby ${{ matrix.ruby-version }}"
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "truffleruby-22", "truffleruby-21"]
+        ruby-version:
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
+          - truffleruby-22
+          - truffleruby-23
         flaky: [false]
         include:
-          - ruby-version: "ruby-head"
+          - ruby-version: "head"
             flaky: true
-          - ruby-version: "jruby-9.2"
+          - ruby-version: "jruby-9.3" # Ruby 2.6.x support
             flaky: true
-          - ruby-version: "jruby-9.3"
+          - ruby-version: "jruby-9.4" # Ruby 3.1.x support
             flaky: true
           - ruby-version: "jruby-head"
             flaky: true
           - ruby-version: "truffleruby-head"
             flaky: true
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
+      - uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
       - name: Bundle install
         run: |
           gem install bundler
-          bundle install
+          bundle config path vendor/bundle
+          bundle install -j $(getconf _NPROCESSORS_ONLN) --retry 3
+
       - name: Run Tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         ruby-version:
           - 2.7
-          - 3.0
+          - "3.0"
           - 3.1
           - 3.2
           - truffleruby-22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-${{ hashFiles('../../Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-
-      - uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          bundler-cache: true
 
       - name: Bundle install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - ruby-version: "truffleruby-head"
             flaky: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage
 ri
 *.swp
 Gemfile.lock
+vendor
+.bundle


### PR DESCRIPTION
* drop Ruby < 2.7 (keeps 2.7)
* add Ruby 3.2, 3.3, 3.4
* shift jruby and truffleruby to support latest 2 versions
* update CI dependencies
* cache bundle install to save resources


Thanks for 18 years of active maintenance 🙇 



<img width="1129" alt="image" src="https://github.com/net-ssh/net-sftp/assets/20702503/f2dd08d5-7d8c-449f-9864-693ca9981599">

