### PR TITLE
Align disk read/writes with the commonly used 4 kb block size

### DIFF
--- a/lib/net/sftp/operations/download.rb
+++ b/lib/net/sftp/operations/download.rb
@@ -218,7 +218,7 @@ module Net; module SFTP; module Operations
       def progress; @progress; end
 
       # The default read size.
-      DEFAULT_READ_SIZE = 32_000
+      DEFAULT_READ_SIZE = 32_768
 
       # The number of bytes to read at a time from remote files.
       def read_size

--- a/lib/net/sftp/operations/upload.rb
+++ b/lib/net/sftp/operations/upload.rb
@@ -230,7 +230,7 @@ module Net; module SFTP; module Operations
       LiveFile = Struct.new(:local, :remote, :io, :size, :handle)
 
       # The default # of bytes to read from disk at a time.
-      DEFAULT_READ_SIZE   = 32_000
+      DEFAULT_READ_SIZE   = 32_768
 
       # The number of readers to use when uploading a single file.
       SINGLE_FILE_READERS = 2


### PR DESCRIPTION
The most commonly used default block size on most *nix file systems is 4 kb.

On a Linux system the actual block size can be display using the command `stat -f .`

Disk read and writes aligned to the block size to avoids unnecessary IO operations.

Caches and smart filesystem driver mitigates unaligned writes, but these limitations still exists.

Yes, I know - this is a very pedantic pull request.