### PR TITLE
Handle Pathname in download/upload

### DIFF
--- a/lib/net/sftp/operations/download.rb
+++ b/lib/net/sftp/operations/download.rb
@@ -145,6 +145,9 @@ module Net; module SFTP; module Operations
     # This will return immediately, and requires that the SSH event loop be
     # run in order to effect the download. (See #wait.)
     def initialize(sftp, local, remote, options={}, &progress)
+      local = local.to_path if local.is_a?(Pathname)
+      remote = remote.to_path if remote.is_a?(Pathname)
+
       @sftp = sftp
       @local = local
       @remote = remote

--- a/lib/net/sftp/operations/upload.rb
+++ b/lib/net/sftp/operations/upload.rb
@@ -141,6 +141,9 @@ module Net; module SFTP; module Operations
     # This will return immediately, and requires that the SSH event loop be
     # run in order to effect the upload. (See #wait.)
     def initialize(sftp, local, remote, options={}, &progress) #:nodoc:
+      local = local.to_path if local.is_a?(Pathname)
+      remote = remote.to_path if remote.is_a?(Pathname)
+
       @sftp = sftp
       @local = local
       @remote = remote

--- a/test/common.rb
+++ b/test/common.rb
@@ -1,6 +1,7 @@
 require 'minitest/autorun'
 require 'mocha/minitest'
 require 'stringio'
+require 'pathname'
 
 begin
   require 'net/ssh'

--- a/test/test_download.rb
+++ b/test/test_download.rb
@@ -35,6 +35,20 @@ class DownloadTest < Net::SFTP::TestCase
     assert_equal text, file.string
   end
 
+  def test_download_file_should_handle_Pathname
+    local = Pathname.new("/path/to/local").freeze
+    remote = Pathname.new("/path/to/remote").freeze
+    text = "this is some text\n"
+
+    expect_file_transfer(remote.to_s, text)
+
+    file = StringIO.new
+    File.stubs(:open).with(local.to_s, "wb").returns(file)
+
+    assert_scripted_command { sftp.download(remote, local) }
+    assert_equal text, file.string
+  end
+
   def test_download_large_file_should_transfer_remote_to_local
     local = "/path/to/local"
     remote = "/path/to/remote"

--- a/test/test_upload.rb
+++ b/test/test_upload.rb
@@ -10,6 +10,13 @@ class UploadTest < Net::SFTP::TestCase
     assert_scripted_command { sftp.upload("/path/to/local", "/path/to/remote") }
   end
 
+  def test_upload_file_should_handle_Pathname
+    local = Pathname.new("/path/to/local").freeze
+    remote = Pathname.new("/path/to/remote").freeze
+    expect_file_transfer(local.to_s, remote.to_s, "here are the contents")
+    assert_scripted_command { sftp.upload(local, remote) }
+  end
+
   def test_upload_file_without_remote_uses_filename_of_local_file
     expect_file_transfer("/path/to/local", "local", "here are the contents")
 


### PR DESCRIPTION
This implements the suggested solution 2.) from #102 for handling `Pathname` instances in `net-sftp`.
